### PR TITLE
fixed possible critical section issue 

### DIFF
--- a/src/CPSC559/UsageChecker.java
+++ b/src/CPSC559/UsageChecker.java
@@ -29,7 +29,6 @@ public class UsageChecker implements Runnable {
 	
 	public UsageChecker(int id, int numOfReplicas) {
 		if(!initialized) {
-			initialized = true;
 			init(numOfReplicas);
 		}
 		this.id = id;
@@ -93,7 +92,10 @@ public class UsageChecker implements Runnable {
 	}
 	
 	private static synchronized void init(int numOfReplicas) {
-		
+		if(initialized) {
+			return;
+		}
+		initialized = true;
 		for(int i = 9001; i < (9001 + numOfReplicas); ++i) {
 			socketUsage.add(new SocketUsagePair(i, -1));
 		}


### PR DESCRIPTION
I noticed a possible critical section issue with the initialization of the usagechecker pair initialization. Should be fixed now. Moved the checking and changing of the "initialized" boolean from the class constructor into the init() function.